### PR TITLE
Fix up docs strings with typos

### DIFF
--- a/analyzer/analyzer_altitude_estimate_divergence.h
+++ b/analyzer/analyzer_altitude_estimate_divergence.h
@@ -21,7 +21,7 @@ class Analyzer_Altitude_Estimate_Divergence : public Analyzer_Estimate_Divergenc
 public:
 
     Analyzer_Altitude_Estimate_Divergence(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer_Estimate_Divergence(vehicle,data_sources)
+    Analyzer_Estimate_Divergence(vehicle,data_sources)
     { }
 
     const std::string estimate_name() const {

--- a/analyzer/analyzer_any_parameters_seen.h
+++ b/analyzer/analyzer_any_parameters_seen.h
@@ -21,12 +21,12 @@ class Analyzer_Any_Parameters_Seen : public Analyzer {
 public:
 
     Analyzer_Any_Parameters_Seen(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     const std::string name() const override { return "Any Parameters Seen"; }
     const std::string description() const override {
-        return "Autopilots store information on-board in the form of parameters.  For proper analysis, logs must contain this parameter information.  This test will FAIL if the input does not contain parameter information.";
+        return "Autopilots store configuration settings known as 'parameters'. For proper analysis, logs must contain this parameter information. This test will FAIL if the input does not contain parameter information.";
     }
 
     void evaluate() override;

--- a/analyzer/analyzer_arming_checks.h
+++ b/analyzer/analyzer_arming_checks.h
@@ -21,12 +21,12 @@ class Analyzer_Arming_Checks : public Analyzer {
 public:
 
     Analyzer_Arming_Checks(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     const std::string name() const override { return "Arming Checks"; }
     const std::string description() const override {
-        return "An autopilot checks many aspects of the aircraft's state before allowing it to be armed - for example, that it has a good GPS fix.  This test will FAIL if the craft ever arms when some arming checks are disabled";
+        return "An autopilot checks many aspects of the aircraft's state before allowing it to be armed - for example, that it has a good GPS fix.  This test will FAIL if the craft ever arms when some arming checks are disabled.";
     }
 
     void evaluate() override;

--- a/analyzer/analyzer_attitude_control.h
+++ b/analyzer/analyzer_attitude_control.h
@@ -30,7 +30,7 @@ class Analyzer_Attitude_Control : public Analyzer {
 public:
 
     Analyzer_Attitude_Control(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     const std::string name() const override { return "Attitude Control"; }

--- a/analyzer/analyzer_attitude_estimate_divergence.h
+++ b/analyzer/analyzer_attitude_estimate_divergence.h
@@ -22,7 +22,7 @@ class Analyzer_Attitude_Estimate_Divergence : public Analyzer_Estimate_Divergenc
 public:
 
     Analyzer_Attitude_Estimate_Divergence(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer_Estimate_Divergence(vehicle,data_sources)
+    Analyzer_Estimate_Divergence(vehicle,data_sources)
     { }
 
     const std::string estimate_name() const {

--- a/analyzer/analyzer_autopilot.h
+++ b/analyzer/analyzer_autopilot.h
@@ -24,7 +24,7 @@ class Analyzer_Autopilot : public Analyzer {
 
 public:
     Analyzer_Autopilot(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle, data_sources),
+    Analyzer(vehicle, data_sources),
         _result_slices_max(NULL)
     { }
 
@@ -36,7 +36,7 @@ public:
 
     const std::string name() const override { return "AutoPilot Health"; }
     const std::string description() const override {
-        return "Many autopilots are capable of monitoring their own performance.  This test will FAIL if problems are detected with the autopilot";
+        return "Many autopilots are capable of monitoring their own performance.  This test will FAIL if problems are detected with the autopilot.";
     }
 
     bool configure(INIReader *config) override;

--- a/analyzer/analyzer_battery.h
+++ b/analyzer/analyzer_battery.h
@@ -21,7 +21,7 @@ class Analyzer_Battery : public Analyzer {
 public:
 
     Analyzer_Battery(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     {
         result = new Analyzer_Battery_Result();
         result->add_source(_data_sources.get("BATTERY_REMAINING"));
@@ -31,7 +31,7 @@ public:
 
     const std::string name() const override { return "Battery"; }
     const std::string description() const override {
-        return "Many autpilots are capable of monitoring their flight batteries.  This test will FAIL if the battery level falls below the battery failsafe threshold level, or if a battery failsafe event is received.";
+        return "Many autopilots are capable of monitoring their flight batteries.  This test will FAIL if the battery level falls below the battery failsafe threshold level, or if a battery failsafe event is received.";
     }
     bool configure(INIReader *config) override;
 

--- a/analyzer/analyzer_brownout.h
+++ b/analyzer/analyzer_brownout.h
@@ -33,7 +33,7 @@ class Analyzer_Brownout : public Analyzer {
 public:
 
     Analyzer_Brownout(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     const std::string name() const override { return "Brownout"; }

--- a/analyzer/analyzer_compass_offsets.h
+++ b/analyzer/analyzer_compass_offsets.h
@@ -29,13 +29,13 @@ class Analyzer_Compass_Offsets : public Analyzer {
 public:
 
     Analyzer_Compass_Offsets(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources, const std::string param_extra_string) :
-	Analyzer(vehicle,data_sources),
+    Analyzer(vehicle,data_sources),
         _param_extra_string(param_extra_string)
     { }
 
     const std::string name() const override { return "Compass Offsets"; }
     const std::string description() const override {
-        return "Compass calibration process produces a set of parameters that specify expected compass discrepancies.  This test will WARN or FAIL depending on the degree that these compass offset parameters exceed specified thresholds.";
+        return "Compass calibration produces a set of parameters that specify expected compass discrepancies.  This test will WARN or FAIL depending on the degree that these compass offset parameters exceed specified thresholds.";
     }
 
     bool configure(INIReader *config) override;

--- a/analyzer/analyzer_compass_vector_length.h
+++ b/analyzer/analyzer_compass_vector_length.h
@@ -39,12 +39,12 @@ class Analyzer_Compass_Vector_Length : public Analyzer {
 public:
 
     Analyzer_Compass_Vector_Length(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     const std::string name() const override { return "Compass Vector Length"; }
     const std::string description() const override {
-        return "The strength and direction of the Earth's magnetic field should be relatively constant and lay within certain thresholds.  This test will FAIL or WARN if the compass vector length exceeds the respective threshold.  Possible causes include flying near large metal objects.";
+        return "The strength and direction of the Earth's magnetic field should be relatively constant and lie within certain thresholds.  This test will FAIL or WARN if the compass vector length exceeds the respective threshold.  Possible causes include flying near large metal objects.";
     }
 
     bool configure(INIReader *config) override;

--- a/analyzer/analyzer_estimate_divergence.h
+++ b/analyzer/analyzer_estimate_divergence.h
@@ -37,7 +37,7 @@ class Analyzer_Estimate_Divergence : public Analyzer {
 public:
 
     Analyzer_Estimate_Divergence(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     virtual const std::string estimate_name() const = 0;
@@ -46,7 +46,7 @@ public:
         return string_format("%s Estimate Divergence", estimate_name().c_str());
     }
     virtual const std::string description() const override {
-        return string_format("A UAV often has several estimates of its %s.  This test will FAIL or WARN if the various vehicle's %s estimates diverge", estimate_name().c_str(), estimate_name().c_str());
+        return string_format("A UAV often has several estimates of its %s.  This test will FAIL or WARN if the various vehicle's %s estimates diverge.", estimate_name().c_str(), estimate_name().c_str());
     }
 
     // void evaluate() override;

--- a/analyzer/analyzer_ever_armed.h
+++ b/analyzer/analyzer_ever_armed.h
@@ -28,14 +28,14 @@ class Analyzer_Ever_Armed : public Analyzer {
 public:
 
     Analyzer_Ever_Armed(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     bool configure(INIReader *config);
 
     const std::string name() const override { return "Ever Armed"; }
     const std::string description() const override {
-        return "Vehicles typically need to progress through a sequence of arming steps before they can move.  This test will FAIL if the craft did not arm";
+        return "Vehicles typically need to progress through a sequence of arming steps before they can move.  This test will FAIL if the craft did not arm.";
     }
 
     void evaluate() override;

--- a/analyzer/analyzer_ever_flew.h
+++ b/analyzer/analyzer_ever_flew.h
@@ -36,7 +36,7 @@ class Analyzer_Ever_Flew : public Analyzer {
 public:
 
     Analyzer_Ever_Flew(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     {
         _result.set_status(analyzer_status_fail);
         _result.set_reason("The vehicle never seemed to take off");
@@ -45,7 +45,7 @@ public:
 
     const std::string name() const { return "Ever Flew"; }
     const std::string description() const {
-        return "Determining whether a vehicle has ever flown in a log is done heuristically based on things like motor speeds.  This test will FAIL if the craft did not ever seem to fly";
+        return "Determining whether a vehicle has ever flown in a log is done heuristically based on things like motor speeds.  This test will FAIL if the craft did not ever seem to fly.";
     }
 
     bool configure(INIReader *config) override;

--- a/analyzer/analyzer_good_ekf.h
+++ b/analyzer/analyzer_good_ekf.h
@@ -48,7 +48,7 @@ public:
 
     const std::string name() const override { return "Good EKF"; }
     const std::string description() const override {
-        return "The Extended Kalman filter has many built-in checks to ensure it is funcitoning correctly.  This test will FAIL or WARN if EKF variances exceed the respective thresholds, or FAIL if the EKF status flags indicate errors.";
+        return "The Extended Kalman Filter (EKF) has many built-in checks to ensure that it is functioning correctly.  This test will FAIL or WARN if EKF variances exceed the respective thresholds, or FAIL if the EKF status flags indicate errors.";
     }
 
     bool configure(INIReader *config) override;

--- a/analyzer/analyzer_gps_fix.h
+++ b/analyzer/analyzer_gps_fix.h
@@ -44,13 +44,13 @@ class Analyzer_GPS_Fix : public Analyzer {
 
 public:
     Analyzer_GPS_Fix(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle, data_sources)
+    Analyzer(vehicle, data_sources)
     { }
 
 
     const std::string name() const override { return "GPS Fix"; }
     const std::string description() const override {
-        return "The accuracy and precision of GPS messages can vary depending on many factors including weather, ionospheric disturbances and number of satellites visible.  This test will FAIL if the quality of the GPS information is poor";
+        return "The accuracy and precision of GPS messages can vary depending on many factors including weather, ionospheric disturbances and number of satellites visible.  This test will FAIL if the quality of the GPS information is poor.";
     }
 
     bool configure(INIReader *config) override;

--- a/analyzer/analyzer_notcrashed.h
+++ b/analyzer/analyzer_notcrashed.h
@@ -25,14 +25,14 @@ class Analyzer_NotCrashed : public Analyzer {
 public:
 
     Analyzer_NotCrashed(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     const uint16_t servo_output_threshold = 1250;
     
     const std::string name() const override { return "Crash Test"; }
     const std::string description() const override {
-        return "Crashes are detected both heuristically and by explicit log messages.  This test will FAIL if the vehicle appears to crash";
+        return "Crashes are detected both heuristically and by explicit log messages.  This test will FAIL if the vehicle appears to crash.";
     }
 
     void end_of_log(const uint32_t packet_count) override;

--- a/analyzer/analyzer_position_estimate_divergence.h
+++ b/analyzer/analyzer_position_estimate_divergence.h
@@ -21,7 +21,7 @@ class Analyzer_Position_Estimate_Divergence : public Analyzer_Estimate_Divergenc
 public:
 
     Analyzer_Position_Estimate_Divergence(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer_Estimate_Divergence(vehicle,data_sources)
+    Analyzer_Estimate_Divergence(vehicle,data_sources)
     { }
 
     const std::string estimate_name() const override {

--- a/analyzer/analyzer_sensor_health.h
+++ b/analyzer/analyzer_sensor_health.h
@@ -26,13 +26,13 @@ class Analyzer_Sensor_Health : public Analyzer {
 
 public:
     Analyzer_Sensor_Health(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle, data_sources)
+    Analyzer(vehicle, data_sources)
     { }
 
 
     const std::string name() const override { return "Sensor Health"; }
     const std::string description() const override {
-        return "A UAV can self-assess its sensors' health.  This test will FAIL if any sensor is detected as failed";
+        return "A UAV can self-assess its sensors' health.  This test will FAIL if any sensor is detected as failed.";
     }
 
     bool configure(INIReader *config) override;

--- a/analyzer/analyzer_vehicle_definition.h
+++ b/analyzer/analyzer_vehicle_definition.h
@@ -21,12 +21,12 @@ class Analyzer_Vehicle_Definition : public Analyzer {
 public:
 
     Analyzer_Vehicle_Definition(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer(vehicle,data_sources)
+    Analyzer(vehicle,data_sources)
     { }
 
     const std::string name() const override { return "Vehicle Definition"; }
     const std::string description() const override {
-        return "The vehicle type is normally automatically detected by dronekit-la from the log itself.  Sometimes the log does not contain sufficient information to make this determination.  This test will FAIL if the craft type is never defined";
+        return "The vehicle type is normally automatically detected by dronekit-la from the log.  Sometimes the log does not contain sufficient information to make this determination.  This test will FAIL if the craft type is never defined";
     }
 
     void evaluate() override;

--- a/analyzer/analyzer_velocity_estimate_divergence.h
+++ b/analyzer/analyzer_velocity_estimate_divergence.h
@@ -21,12 +21,12 @@ class Analyzer_Velocity_Estimate_Divergence : public Analyzer_Estimate_Divergenc
 public:
 
     Analyzer_Velocity_Estimate_Divergence(AnalyzerVehicle::Base *&vehicle, Data_Sources &data_sources) :
-	Analyzer_Estimate_Divergence(vehicle,data_sources)
+    Analyzer_Estimate_Divergence(vehicle,data_sources)
     { }
 
     const std::string name() const override { return "Velocity Estimate Divergence"; }
     const std::string description() const override {
-        return "A UAV typically has several estimates of its velocity.  This test will FAIL if the craft's velocity estimates diverge";
+        return "A UAV typically has several estimates of its velocity.  This test will FAIL if the craft's velocity estimates diverge.";
     }
 
     const std::string estimate_name() const {


### PR DESCRIPTION
This updates source to fix the analyser descriptions - a few typos and full-stops at the ends. It addresses #45 
