### PR TITLE
analyzer: include missing headers

### DIFF
--- a/analyzer/analyzer_compass_vector_length.h
+++ b/analyzer/analyzer_compass_vector_length.h
@@ -8,6 +8,8 @@
 
 #include "analyzer.h"
 
+#include <functional>
+
 class Analyzer_Compass_Vector_Length_Result_Short : public Analyzer_Result_Period {
     friend class Analyzer_Compass_Vector_Length;
 public:

--- a/analyzer/analyzer_gyro_drift.h
+++ b/analyzer/analyzer_gyro_drift.h
@@ -8,6 +8,8 @@
 
 #include "analyzer.h"
 
+#include <functional>
+
 class Analyzer_Gyro_Drift_Result : public Analyzer_Result_Period {
     friend class Analyzer_Gyro_Drift;
 public:


### PR DESCRIPTION
These are needed for std::function, otherwise it fails to build with gcc
7 on Fedora 26.