### PR TITLE
Reduce the priority of the repeated heartbeat message.

### DIFF
--- a/dataflash_logger.cpp
+++ b/dataflash_logger.cpp
@@ -20,7 +20,7 @@ void DataFlash_Logger::idle_tenthHz()
 {
     // the following isn't quite right given we seek around...
     if (logging_started) {
-	la_log(LOG_INFO, "mh-dfl: Current log size: %lu", lseek(out_fd, 0, SEEK_CUR));
+	la_log(LOG_DEBUG, "mh-dfl: Current log size: %lu", lseek(out_fd, 0, SEEK_CUR));
     }
 }
 

--- a/heart.cpp
+++ b/heart.cpp
@@ -29,7 +29,7 @@ void Heart::beat()
     uint32_t custom_mode = 0;
     uint8_t system_status = 0;
 
-    la_log(LOG_INFO, "mh-h: sending heartbeat");
+    la_log(LOG_DEBUG, "mh-h: sending heartbeat");
 
     mavlink_msg_heartbeat_pack(system_id, component_id, &msg, type, autopilot, base_mode, custom_mode, system_status);
 

--- a/la-log.h
+++ b/la-log.h
@@ -7,6 +7,7 @@
 #ifndef _WIN32
 #include <syslog.h>
 #else
+#define LOG_DEBUG 0
 #define LOG_INFO 1
 #define LOG_ERR 2
 #define LOG_CRIT 3


### PR DESCRIPTION
Repeated publishing of the 'sending heartbeat' message tends to fill up logs and is probably not necessary; this facilitates suppressing it.