### PR TITLE
Update analyzer_subsys_errors.cpp

### DIFF
--- a/analyzer/analyzer_subsys_errors.cpp
+++ b/analyzer/analyzer_subsys_errors.cpp
@@ -135,7 +135,7 @@ const std::string Analyzer_Subsys_Errors::ecode_string(uint32_t subsys,
     try {
         std::map<const uint32_t, const std::string> bob = _subsys_errors_strings.at(subsys);
         return bob.at(ecode);
-    } catch (std::out_of_range) {
+    } catch (std::out_of_range&) {
     }
     switch(ecode) {
     case ERROR_CODE_ERROR_RESOLVED:


### PR DESCRIPTION
Fix make error with GCC 8.3 because of catch by value of std::out_of_range